### PR TITLE
Add `checkout-against-tandem` Script 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,15 @@ GO ?= go
 
 # NOTE: `*** missing separator.  Stop.` may be an indication of spaces being used, rather than tabs
 
+# Script to make branch against Tandem
+checkout-against-tandem:
+	./scripts/checkout-against-tandem.sh
+
 # Go Vendor Commands
 deps-all: deps-ts-services deps-go-services
 
-deps-ts-services: deps-ts-libraries deps-web-frontend
+# Run ts dependencies to account for local ts cross-dependencies where order matters
+deps-ts-services: deps-ts-libraries deps-ts-libraries deps-web-frontend
 
 deps-go-services: deps-golang deps-public-api deps-grpc
 

--- a/scripts/checkout-against-tandem
+++ b/scripts/checkout-against-tandem
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# 1. Get master commit
+MASTER_SHA=$( cat ../.git/refs/heads/master )
+
+# Commits in order of earliest to latest
+SHAs=()
+
+# 2. Gather SHAs of unique commits, going back to masterSHA
+INDEX=0
+while [ true ]
+do
+  COMMIT=$( git rev-parse HEAD~$INDEX )
+  if [ $COMMIT == $MASTER_SHA ]; then
+    break
+  else
+    SHAs=($COMMIT ${SHAs[@]})
+    # echo $commit $index
+    # echo "${SHAs[@]}"
+    INDEX=$((INDEX+1))
+  fi
+done
+
+# 3. make branch name
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO=$(basename $(dirname $DIR))
+if [ $REPO == "tandem" ]; then
+  echo "Already within Tandem -- directly make branch against master."
+  exit
+fi
+BRANCH=$(git branch --show-current)
+NEW_BRANCH=$REPO/$BRANCH
+
+# 4. Need to checkout tandem as base and cherry-pick commits onto it
+git remote add upstream git@github.com:stevenelleman/tandem.git
+git fetch upstream
+git checkout -b $NEW_BRANCH upstream/$NEW_BRANCH
+for COMMIT in SHAs
+do
+  git cherry-pick $COMMIT
+done
+
+
+

--- a/scripts/checkout-against-tandem.sh
+++ b/scripts/checkout-against-tandem.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# 1. Get master commit
+MASTER_SHA=$( cat .git/refs/heads/master )
+
+# Commits in order of earliest to latest
+SHAs=()
+
+# 2. Gather SHAs of unique commits, going back to masterSHA
+INDEX=0
+while [ true ]
+do
+  COMMIT=$( git rev-parse HEAD~$INDEX )
+  if [ $COMMIT == $MASTER_SHA ]; then
+    break
+  else
+    SHAs=($COMMIT ${SHAs[@]})
+    # echo $commit $index
+    # echo "${SHAs[@]}"
+    INDEX=$((INDEX+1))
+  fi
+done
+
+# 3. make branch name
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO=$(basename $(dirname $DIR))
+if [ $REPO == "tandem" ]; then
+  echo "Already within Tandem -- directly make branch against master."
+  exit
+fi
+BRANCH=$(git branch --show-current)
+NEW_BRANCH=$REPO/$BRANCH
+
+# 4. Need to checkout tandem as base and cherry-pick commits onto it
+git remote add upstream git@github.com:stevenelleman/tandem.git
+git fetch upstream
+git checkout -b $NEW_BRANCH upstream/$NEW_BRANCH
+for COMMIT in SHAs
+do
+  git cherry-pick $COMMIT
+done
+
+
+


### PR DESCRIPTION
## Terms

## What
When a change is being made to Tandem from a forked library it's necessary that _only_ the unique branch commits (and not commits belonging to that fork) are merged into Tandem.  

## How 
1. Get commit SHAs on branch
2. Make new branch based on `tandem:master`
3. Cherry-pick commits onto the new branch 

## Why 
This script prepares such a new branch that can be easily and sanely merged into Tandem. 
## Tasks 

## Notes to Reviewers 

## Meta 